### PR TITLE
NO-JIRA: Update cleanup_rhel_ai server name

### DIFF
--- a/nested-passthrough/Makefile
+++ b/nested-passthrough/Makefile
@@ -171,5 +171,5 @@ cleanup_edpm: ## Delete the eDPM node
 .PHONY: cleanup_rhel_ai
 cleanup_rhel_ai: ## Delete the RHEL AI instance running in RHOSO
 	@scripts/http-serve.sh stop
-	@source $$(crc oc-env) && \
-	oc rsh openstackclient openstack server delete nvidia
+	@eval $$(crc oc-env) && \
+	oc rsh openstackclient openstack server delete rhel-ai


### PR DESCRIPTION
**What does this PR do?**
Use `eval` instead of `source`
Update the `cleanup_rhel_ai` target to use the RHELAI instance server name: `rhel_ai`. 

**Why do we need it?**
To fix the `cleanup_rhel_ai` error: 
```
/bin/sh: line 1: source: export: file not found
make: *** [Makefile:174: cleanup_rhel_ai] Error 1
```
That error comes from the use of `source` instead of `eval`, following the rhel_ai instance server name is `rhel_ai`, not `nvidia`